### PR TITLE
S3 로직 변경 및 Product에서 @Auth 사용하는 방향으로 수정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,6 +9,8 @@ http {
 
     include /etc/nginx/mime.types;
 
+    charset utf-8;
+
     server {
         listen 80;
         server_name localhost;

--- a/rebook-common/src/main/java/com/be/rebook/common/service/S3Service.java
+++ b/rebook-common/src/main/java/com/be/rebook/common/service/S3Service.java
@@ -2,6 +2,7 @@ package com.be.rebook.common.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.be.rebook.common.type.S3FolderName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,19 +20,37 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadFile(MultipartFile file) throws IOException {
+    /**
+     * 이미지 파일 업로드
+     * file -> 파일 자체를 매개변수로
+     * folderName -> 해당 폴더 기입(Ex. "S3FolderName.PRODUCT")
+     */
+    public String uploadFile(MultipartFile file, S3FolderName folderName) throws IOException {
         // 원본 파일명
         String originalFileName = file.getOriginalFilename();
         // 저장 파일명
         String storeFileName = createStoreFileName(originalFileName);
 
+        // S3에 저장될 전체 경로
+        String fullPath = folderName.getFolderName() + "/" + storeFileName;
+
         // S3에 저장
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(file.getContentType());
         metadata.setContentLength(file.getSize());
-        amazonS3Client.putObject(bucket, storeFileName, file.getInputStream(), metadata);
+        amazonS3Client.putObject(bucket, fullPath, file.getInputStream(), metadata);
 
         return storeFileName;
+    }
+
+    /**
+     * S3 버킷에서 파일 삭제
+     * folderName -> 해당 폴더이름 기입(Ex."S3FolderName.PRODUCT")
+     * fileName -> 해당 이미지의 storeFileName을 넣으면 됨
+     */
+    public void deleteFile(S3FolderName folderName, String fileName) {
+        String fullPath = folderName.getFolderName() + "/" + fileName;
+        amazonS3Client.deleteObject(bucket, fullPath);
     }
 
     /**

--- a/rebook-common/src/main/java/com/be/rebook/common/type/S3FolderName.java
+++ b/rebook-common/src/main/java/com/be/rebook/common/type/S3FolderName.java
@@ -1,0 +1,17 @@
+package com.be.rebook.common.type;
+
+public enum S3FolderName {
+    PROFILE("profile"),
+    PRODUCT("product"),
+    CHAT("chat");
+
+    private final String folderName;
+
+    S3FolderName(String folderName) {
+        this.folderName = folderName;
+    }
+
+    public String getFolderName() {
+        return folderName;
+    }
+}

--- a/rebook-common/src/resources/application.yml
+++ b/rebook-common/src/resources/application.yml
@@ -1,7 +1,7 @@
 cloud:
   aws:
     s3:
-      bucket: rebookbucket
+      bucket: rb-dev-s3-images
     stack.auto: false
     region.static: ap-northeast-2
     credentials:

--- a/rebook-product/src/main/java/com/be/rebook/product/controller/ProductController.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/controller/ProductController.java
@@ -28,7 +28,7 @@ public class ProductController {
     /**
      * 상품 등록
      */
-    @PostMapping("/me") // TODO:유저정보는 Auth 모듈 활용해서 가져오기
+    @PostMapping
     public ResponseEntity<BaseResponse<Long>> createProduct(@Auth MemberLoginInfo memberLoginInfo,
                                                             @RequestPart("productRequest") ProductSaveRequestDTO productSaveRequestDTO,
                                                             @RequestPart("imageFiles") List<MultipartFile> imageFiles) throws IOException {

--- a/rebook-product/src/main/java/com/be/rebook/product/controller/ProductController.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/controller/ProductController.java
@@ -1,7 +1,10 @@
 package com.be.rebook.product.controller;
 
+import com.be.rebook.common.argumentresolver.auth.Auth;
+import com.be.rebook.common.argumentresolver.auth.MemberLoginInfo;
 import com.be.rebook.common.config.BaseResponse;
 import com.be.rebook.product.service.ProductService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,37 +28,31 @@ public class ProductController {
     /**
      * 상품 등록
      */
-    @PostMapping("/members/{memberId}") // TODO:유저정보는 Auth 모듈 활용해서 가져오기
-    public ResponseEntity<BaseResponse<Long>> createProduct(@PathVariable("memberId") Long memberId,
+    @PostMapping("/me") // TODO:유저정보는 Auth 모듈 활용해서 가져오기
+    public ResponseEntity<BaseResponse<Long>> createProduct(@Auth MemberLoginInfo memberLoginInfo,
                                                             @RequestPart("productRequest") ProductSaveRequestDTO productSaveRequestDTO,
                                                             @RequestPart("imageFiles") List<MultipartFile> imageFiles) throws IOException {
         return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(
                 HttpStatus.CREATED,
                 "201 CREATED",
                 "상품이 등록되었습니다.",
-                productService.createProduct(memberId, productSaveRequestDTO, imageFiles)));
+                productService.createProduct(memberLoginInfo.getUsername(), productSaveRequestDTO, imageFiles)));
     }
 
     /**
      * 상품 목록 조회
      */
     @GetMapping
-    public ResponseEntity<BaseResponse<List<ProductListResponseDTO>>> findAllProduct(
-            @RequestParam(required = false) String university,
-            @RequestParam(required = false) String major,
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) Integer minPrice,
-            @RequestParam(required = false) Integer maxPrice,
-            @RequestParam(required = false) String order) {
-        return ResponseEntity.ok().body(new BaseResponse<>(productService.findAllProductByFilter(university, major, title, minPrice, maxPrice, order)));
+    public ResponseEntity<BaseResponse<List<ProductListResponseDTO>>> findAllProduct(@Valid @ModelAttribute ProductFilterDTO productFilterDTO) {
+        return ResponseEntity.ok().body(new BaseResponse<>(productService.findAllProductByFilter(productFilterDTO)));
     }
 
     /**
      * 내가 쓴 글 조회
      */
-    @GetMapping("/members/{memberId}/products")
-    public ResponseEntity<BaseResponse<List<ProductListResponseDTO>>> findProductsByMember(@PathVariable("memberId") Long memberId) {
-        return ResponseEntity.ok().body(new BaseResponse<>(productService.findAllProductBySellerId(memberId)));
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<List<ProductListResponseDTO>>> findProductsByMember(@Auth MemberLoginInfo memberLoginInfo) {
+        return ResponseEntity.ok().body(new BaseResponse<>(productService.findAllMyProducts(memberLoginInfo.getUsername())));
     }
 
     /**

--- a/rebook-product/src/main/java/com/be/rebook/product/dto/ProductRequestDTO.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/dto/ProductRequestDTO.java
@@ -1,9 +1,7 @@
 package com.be.rebook.product.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Min;
+import lombok.*;
 
 public class ProductRequestDTO {
 
@@ -27,5 +25,33 @@ public class ProductRequestDTO {
     @AllArgsConstructor
     public static class ProductStatusRequestDTO {
         private String status;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProductFilterDTO {
+
+        @Builder.Default
+        private String university = "";
+
+        @Builder.Default
+        private String major = "";
+
+        @Builder.Default
+        private String title = "";
+
+        @Builder.Default
+        @Min(value = 0, message = "최저가는 0이상이어야 합니다.")
+        private Integer minPrice = 0;
+
+        @Builder.Default
+        @Min(value = 0, message = "최고가는 0이상이어야 합니다.")
+        private Integer maxPrice = Integer.MAX_VALUE;
+
+        @Builder.Default
+        private String order = "";
     }
 }

--- a/rebook-product/src/main/java/com/be/rebook/product/dto/ProductResponseDTO.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/dto/ProductResponseDTO.java
@@ -49,7 +49,7 @@ public class ProductResponseDTO {
 
         private List<String> storeFileNameList;
 
-        private Long sellerId;
+        private String sellerUsername;
 
         private String title;
 
@@ -70,7 +70,7 @@ public class ProductResponseDTO {
             this.storeFileNameList = product.getProductImages().stream()
                     .map(ProductImage::getStoreFileName)
                     .collect(Collectors.toList());
-            this.sellerId = product.getSellerId();
+            this.sellerUsername = product.getSellerUsername();
             this.title = product.getTitle();
             this.content = product.getContent();
             this.price = product.getPrice();

--- a/rebook-product/src/main/java/com/be/rebook/product/entity/Product.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/entity/Product.java
@@ -34,12 +34,12 @@ public class Product extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    private Long sellerId;
+    private String sellerUsername;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductImage> productImages = new ArrayList<>();
 
-    public static Product of(Long sellerId, ProductRequestDTO.ProductSaveRequestDTO productSaveRequestDTO) {
+    public static Product of(String sellerUsername, ProductRequestDTO.ProductSaveRequestDTO productSaveRequestDTO) {
         return builder()
                 .title(productSaveRequestDTO.getTitle())
                 .content(productSaveRequestDTO.getContent())
@@ -47,7 +47,7 @@ public class Product extends BaseEntity {
                 .university(productSaveRequestDTO.getUniversity())
                 .major(productSaveRequestDTO.getMajor())
                 .status(ProductStatus.PENDING)
-                .sellerId(sellerId)
+                .sellerUsername(sellerUsername)
                 .build();
     }
 

--- a/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepository.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
-    List<Product> findProductsBySellerId(Long sellerId);
+    List<Product> findProductsBySellerUsername(String sellerUsername);
 }

--- a/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepositoryCustom.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.be.rebook.product.repository;
 
+import com.be.rebook.product.dto.ProductRequestDTO;
 import com.be.rebook.product.entity.Product;
 
 import java.util.List;
 
+import static com.be.rebook.product.dto.ProductRequestDTO.*;
+
 public interface ProductRepositoryCustom {
 
-    List<Product> findProductsByFilter(String university, String major, String title, Integer minPrice, Integer maxPrice, String order);
+    List<Product> findProductsByFilter(ProductFilterDTO productFilterDTO);
 }

--- a/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepositoryImpl.java
+++ b/rebook-product/src/main/java/com/be/rebook/product/repository/ProductRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.be.rebook.product.repository;
 
+import com.be.rebook.product.dto.ProductRequestDTO;
 import com.be.rebook.product.entity.Product;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import static com.be.rebook.product.dto.ProductRequestDTO.*;
 import static com.be.rebook.product.entity.QProduct.product;
 
 @RequiredArgsConstructor
@@ -17,28 +19,28 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
 
     @Override
-    public List<Product> findProductsByFilter(String university, String major, String title, Integer minPrice, Integer maxPrice, String order) {
+    public List<Product> findProductsByFilter(ProductFilterDTO productFilterDTO) {
         return jpaQueryFactory.selectFrom(product)
                 .where(
-                        universityContains(university),
-                        majorContains(major),
-                        titleContains(title),
-                        priceBetween(minPrice, maxPrice)
+                        universityContains(productFilterDTO.getUniversity()),
+                        majorContains(productFilterDTO.getMajor()),
+                        titleContains(productFilterDTO.getTitle()),
+                        priceBetween(productFilterDTO.getMinPrice(), productFilterDTO.getMaxPrice())
                 )
-                .orderBy(getOrderSpecifier(order))
+                .orderBy(getOrderSpecifier(productFilterDTO.getOrder()))
                 .fetch();
     }
 
     private BooleanExpression universityContains(String university) {
-        return university != null ? product.university.contains(university) : null;
+        return university != null && !university.isEmpty() ? product.university.contains(university) : null;
     }
 
     private BooleanExpression majorContains(String major) {
-        return major != null ? product.major.contains(major) : null;
+        return major != null && !major.isEmpty() ? product.major.contains(major) : null;
     }
 
     private BooleanExpression titleContains(String title) {
-        return title != null ? product.title.contains(title) : null;
+        return title != null && !title.isEmpty() ? product.title.contains(title) : null;
     }
 
     private BooleanExpression priceBetween(Integer minPrice, Integer maxPrice) {

--- a/rebook-product/src/main/resources/application.yml
+++ b/rebook-product/src/main/resources/application.yml
@@ -24,7 +24,8 @@ spring:
       max-request-size: 30MB
       max-file-size: 30MB
       resolve-lazily: true
-      
+
+
 # Eureka Client 설정
 eureka:
   client:
@@ -55,4 +56,9 @@ cloud:
     credentials:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
-      
+
+# 한글 인코딩 설정
+server:
+  servlet:
+    encoding:
+      charset: UTF-8


### PR DESCRIPTION
 ## 📌 개요
  - S3 이미지 저장을 폴더별로 분리해야합니다.
  - Product에서 memberId를 사용한 API가 아닌 @Auth를 활용해야합니다.
  - Product의 필터 검색 기능의 쿼리파라미터를 DTO로 변경해야 합니다.
  
 ## 💻 작업사항 
  - S3 폴더를 enum타입으로 만들었습니다.
  - S3 이미지 저장을 폴더별로 선택할 수 있게 수정했습니다.
  - S3 삭제 로직을 추가했습니다.
  - Product에서 memberId가 아니라 username을 저장하는 것으로 수정했습니다.
  - Product Controller에 RequestParam을 DTO로 변경했습니다.
  - Product API의 URI를 수정하고 @Auth를 활용하는 코드로 수정했습니다.

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #43 
 - close #44 