### PR TITLE
105 patch : 이메일 토큰 쿠키에서 헤더로 변경 

### DIFF
--- a/rebook-auth/src/main/java/com/be/rebook/auth/service/ReissueService.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/service/ReissueService.java
@@ -43,16 +43,18 @@ public class ReissueService {
     public Members reissueUserPassword(HttpServletRequest request, BasicUserInfoDTO resetPasswordDTO) {
         String mailToken = null;
 
-        if (request.getCookies().length == 0) {
-            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
-        }
+//        if (request.getCookies().length == 0) {
+//            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
+//        }
+//
+//        for (Cookie cookie : request.getCookies()) {
+//            if (cookie.getName().equals(TokenCategory.MAILAUTH.getName())) {
+//                mailToken = cookie.getValue();
+//                break;
+//            }
+//        }
+        mailToken = request.getHeader(TokenCategory.MAILAUTH.getName());
 
-        for (Cookie cookie : request.getCookies()) {
-            if (cookie.getName().equals(TokenCategory.MAILAUTH.getName())) {
-                mailToken = cookie.getValue();
-                break;
-            }
-        }
         if (mailToken == null) {
             // NO_TOKEN_CONTENT
             throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);

--- a/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
@@ -50,13 +50,13 @@ public class SignupService {
     @Transactional
     public Members signupProcess(HttpServletRequest request, BasicUserInfoDTO basicUserInfoDTO) {
         String mailToken = null;
-        mailToken = request.getHeader("mailauth");
 
 //        Cookie mailCookie = cookieUtil.findCookieFromRequest(TokenCategory.MAILAUTH.getName(), request);
 //        if (mailCookie == null) {
 //            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
 //        }
 //        mailToken = mailCookie.getValue();
+        mailToken = request.getHeader(TokenCategory.MAILAUTH.getName());
 
         if (mailToken == null) {
             // NO_TOKEN_CONTENT

--- a/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
@@ -50,12 +50,13 @@ public class SignupService {
     @Transactional
     public Members signupProcess(HttpServletRequest request, BasicUserInfoDTO basicUserInfoDTO) {
         String mailToken = null;
+        mailToken = request.getHeader("mailauth");
 
-        Cookie mailCookie = cookieUtil.findCookieFromRequest(TokenCategory.MAILAUTH.getName(), request);
-        if (mailCookie == null) {
-            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
-        }
-        mailToken = mailCookie.getValue();
+//        Cookie mailCookie = cookieUtil.findCookieFromRequest(TokenCategory.MAILAUTH.getName(), request);
+//        if (mailCookie == null) {
+//            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
+//        }
+//        mailToken = mailCookie.getValue();
 
         if (mailToken == null) {
             // NO_TOKEN_CONTENT

--- a/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/service/SignupService.java
@@ -125,10 +125,7 @@ public class SignupService {
                             username,
                             null,
                             TokenCategory.MAILAUTH.getExpiry());
-            cookieUtil.createCookie(
-                    TokenCategory.MAILAUTH.getName(),
-                    mailToken,
-                    TokenCategory.MAILAUTH.getExpiry().intValue() / 1000, response);
+            response.setHeader(TokenCategory.MAILAUTH.getName(), mailToken);
         }
 
         return Members.builder()

--- a/rebook-auth/src/main/java/com/be/rebook/auth/utility/CookieUtil.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/utility/CookieUtil.java
@@ -42,25 +42,14 @@ public class CookieUtil {
                     .build();
         }
         else {
-            if(key.equals(TokenCategory.MAILAUTH.getName())){
-                cookie = ResponseCookie.from(key, value)
-                        .domain(cookieDomain)
-                        .httpOnly(true)
-                        .maxAge(maxAge)
-                        .secure(true)
-                        .sameSite("None")
-                        .build();
-            }
-            else{
-                cookie = ResponseCookie.from(key, value)
-                        .domain(cookieDomain)
-                        .path("/")
-                        .httpOnly(true)
-                        .maxAge(maxAge)
-                        .secure(true)
-                        .sameSite("None")
-                        .build();
-            }
+            cookie = ResponseCookie.from(key, value)
+                    .domain(cookieDomain)
+                    .path("/")
+                    .httpOnly(true)
+                    .maxAge(maxAge)
+                    .secure(true)
+                    .sameSite("None")
+                    .build();
         }
 
         // 응답에 Set-Cookie 헤더로 추가


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 이메일 토큰을 헤더에 보내는 방식으로 변경했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - signup, password reset에서 요청 헤더에서 mailauth 라는 이름으로 토큰을 추출합니다.
  - verify에서 헤더에 mailauth 토큰을 태워보냅니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #110 