### PR TITLE
patch : mailauth Cookie로 되돌리고 Authorization 헤더 통합 삭제

### DIFF
--- a/rebook-auth/src/main/java/com/be/rebook/auth/controller/AuthController.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/controller/AuthController.java
@@ -39,8 +39,8 @@ public class AuthController {
     private final CookieUtil cookieUtil;
 
     public AuthController(SignupService signupService,
-            ReissueService reissueService,
-            CookieUtil cookieUtil) {
+                          ReissueService reissueService,
+                          CookieUtil cookieUtil) {
         this.signupService = signupService;
         this.reissueService = reissueService;
         this.cookieUtil = cookieUtil;
@@ -48,14 +48,14 @@ public class AuthController {
 
     @PostMapping("/members/signup")
     public ResponseEntity<BaseResponse<Members>> signupProcess(HttpServletRequest request,
-            @Valid @RequestBody BasicUserInfoDTO basicUserInfoDTO) {
+                                                               @Valid @RequestBody BasicUserInfoDTO basicUserInfoDTO) {
         signupLogger.info(basicUserInfoDTO.getUsername());
         return ResponseEntity.ok().body(new BaseResponse<>(signupService.signupProcess(request, basicUserInfoDTO)));
     }
 
     @PostMapping("/members/refreshtoken/reissue")
     public ResponseEntity<BaseResponse<TokenDto>> reissueRefreshToken(HttpServletRequest request,
-            HttpServletResponse response) {
+                                                                      HttpServletResponse response) {
 
         Cookie refreshTokenCookie = cookieUtil.findCookieFromRequest(TokenCategory.REFRESH.getName(), request);
         if (refreshTokenCookie == null) {
@@ -64,8 +64,7 @@ public class AuthController {
 
         TokenDto newToken = reissueService.reissueToken(refreshTokenCookie.getValue());
 
-//        response.setHeader(TokenCategory.ACCESS.getName(), newToken.getAccessToken());
-        response.setHeader("Authorization", newToken.getAccessToken());
+        response.setHeader(TokenCategory.ACCESS.getName(), newToken.getAccessToken());
         cookieUtil
                 .createCookie(TokenCategory.REFRESH.getName(),
                         newToken.getRefreshToken(),
@@ -81,7 +80,7 @@ public class AuthController {
 
     @PostMapping("/members/signup/verify")
     public ResponseEntity<BaseResponse<Members>> codeMatch(HttpServletResponse response,
-            @Valid @RequestBody VerifyDTO verifyDTO) {
+                                                           @Valid @RequestBody VerifyDTO verifyDTO) {
         return ResponseEntity.ok().body(new BaseResponse<>(signupService.verifyCode(verifyDTO, response)));
     }
 
@@ -102,7 +101,7 @@ public class AuthController {
 
     @PatchMapping("/members/password/reset")
     public ResponseEntity<BaseResponse<Members>> resetUserPassword(HttpServletRequest request,
-            @Valid @RequestBody BasicUserInfoDTO resetPasswordDTO) {
+                                                                   @Valid @RequestBody BasicUserInfoDTO resetPasswordDTO) {
         return ResponseEntity.ok()
                 .body(new BaseResponse<>(reissueService.reissueUserPassword(request, resetPasswordDTO)));
     }
@@ -110,7 +109,7 @@ public class AuthController {
     // 로그인 이후 마이페이지에서 바로 비밀번호 변경이라 이메일 인증 필요없음
     @PatchMapping("/members/password")
     public ResponseEntity<BaseResponse<Members>> updateUserPassword(HttpServletRequest request,
-            @Valid @RequestBody UpdatePasswordDTO passwordDTO) {
+                                                                    @Valid @RequestBody UpdatePasswordDTO passwordDTO) {
         String passwordToUpdate = passwordDTO.getPassword();
         return ResponseEntity.ok()
                 .body(new BaseResponse<>(reissueService.updateUserPassword(request, passwordToUpdate)));

--- a/rebook-auth/src/main/java/com/be/rebook/auth/jwt/LoginFilter.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/jwt/LoginFilter.java
@@ -32,8 +32,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final CookieUtil cookieUtil;
 
     public LoginFilter(AuthenticationManager authenticationManager,
-            JWTUtil jwtUtil,
-            CookieUtil cookieUtil) {
+                       JWTUtil jwtUtil,
+                       CookieUtil cookieUtil) {
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
         this.cookieUtil = cookieUtil;
@@ -92,7 +92,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         jwtUtil.saveRefreshToken(username, refresh);
 
-        response.setHeader("Authorization", access);
+        response.setHeader(TokenCategory.ACCESS.getName(), access);
         cookieUtil.createCookie(TokenCategory.REFRESH.getName(), refresh,
                 TokenCategory.REFRESH.getExpiry().intValue() / 1000, response);
         response.setStatus(HttpStatus.OK.value());

--- a/rebook-auth/src/main/java/com/be/rebook/auth/oauth/handler/OAuthAuthenticationSuccessHandler.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/oauth/handler/OAuthAuthenticationSuccessHandler.java
@@ -27,7 +27,7 @@ public class OAuthAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
     private final CookieUtil cookieUtil;
 
     public OAuthAuthenticationSuccessHandler(@Value("${info.web.oauth.targetUrl}") String targetUrl, JWTUtil jwtUtil,
-            CookieUtil cookieUtil) {
+                                             CookieUtil cookieUtil) {
         this.targetUrl = targetUrl;
         this.jwtUtil = jwtUtil;
         this.cookieUtil = cookieUtil;
@@ -36,7 +36,7 @@ public class OAuthAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
     @Transactional
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) throws IOException {
+                                        Authentication authentication) throws IOException {
 
         if (response.isCommitted()) {
             logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
@@ -50,7 +50,7 @@ public class OAuthAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
 
     @Override
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) {
+                                        Authentication authentication) {
         String username = authentication.getName();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -64,7 +64,7 @@ public class OAuthAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
 
         jwtUtil.saveRefreshToken(username, refresh);
 
-        response.setHeader("Authorization", access);
+        response.setHeader(TokenCategory.ACCESS.getName(), access);
         cookieUtil.createCookie(TokenCategory.REFRESH.getName(), refresh,
                 TokenCategory.REFRESH.getExpiry().intValue() / 1000, response);
         response.setStatus(HttpStatus.OK.value());

--- a/rebook-auth/src/main/java/com/be/rebook/auth/service/ReissueService.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/service/ReissueService.java
@@ -30,9 +30,9 @@ public class ReissueService {
     private final MembersRepository membersRepository;
 
     public ReissueService(JWTUtil jwtUtil,
-            MembersRepository membersRepository,
-            BCryptPasswordEncoder bCryptPasswordEncoder,
-            CookieUtil cookieUtil) {
+                          MembersRepository membersRepository,
+                          BCryptPasswordEncoder bCryptPasswordEncoder,
+                          CookieUtil cookieUtil) {
         this.jwtUtil = jwtUtil;
         this.cookieUtil = cookieUtil;
         this.membersRepository = membersRepository;
@@ -42,7 +42,12 @@ public class ReissueService {
     @Transactional
     public Members reissueUserPassword(HttpServletRequest request, BasicUserInfoDTO resetPasswordDTO) {
         String mailToken = null;
-        mailToken = request.getHeader("Authorization");
+
+        Cookie mailCookie = cookieUtil.findCookieFromRequest(TokenCategory.MAILAUTH.getName(), request);
+        if (mailCookie == null) {
+            throw new BaseException(ErrorCode.NO_TOKEN_CONTENT);
+        }
+        mailToken = mailCookie.getValue();
 
         if (mailToken == null) {
             // NO_TOKEN_CONTENT

--- a/rebook-auth/src/main/java/com/be/rebook/auth/utility/CookieUtil.java
+++ b/rebook-auth/src/main/java/com/be/rebook/auth/utility/CookieUtil.java
@@ -4,9 +4,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
-
-import com.be.rebook.auth.jwt.type.TokenCategory;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - mailauth Cookie로 되돌리고 Authorization 헤더 통합 삭제
  - 비밀번호 수정에서 Authorization으로 통합되어있으면 액세스 토큰 못 가져오고, 쿠키로 mailauth도 필요해서 수정합니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #119 